### PR TITLE
Changes to LoomError Enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ impl<T: Config> TapestryFragment<T> {
 	fn push_message(&mut self, msg: ContextMessage<T>) -> Result<()> {
 		let tokens = T::PromptModel::count_tokens(&msg.content)?;
 		let new_token_count = self.context_tokens.checked_add(&tokens).ok_or_else(|| {
-			LoomError::from(WeaveError::BadConfig(
+			LoomError::from_error(WeaveError::BadConfig(
 				"Number of tokens exceeds max tokens for model".to_string(),
 			))
 		})?;
@@ -332,7 +332,7 @@ impl<T: Config> TapestryFragment<T> {
 		trace!("Extending messages with token sum: {}", sum);
 
 		let new_token_count = self.context_tokens.checked_add(&sum).ok_or_else(|| {
-			LoomError::from(WeaveError::BadConfig(
+			LoomError::from_error(WeaveError::BadConfig(
 				"Number of tokens exceeds max tokens for model".to_string(),
 			))
 		})?;

--- a/src/loom.rs
+++ b/src/loom.rs
@@ -150,7 +150,9 @@ impl<T: Config> Loom<T> {
 		trace!("Max completion tokens available: {:?}", max_completion_tokens);
 
 		if max_completion_tokens.is_zero() {
-			return Err(LoomError::from(WeaveError::MaxCompletionTokensIsZero).into());
+			return Err(LoomError::from_error(WeaveError::BadConfig(
+				"Invalid configuration".to_string(),
+			)))
 		}
 
 		trace!("Prompting LLM with request messages");

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -110,7 +110,7 @@ impl Llm<MockConfig> for MockLlm {
 		let tokens = bpe.encode_with_special_tokens(&content.to_string());
 
 		tokens.len().try_into().map_err(|_| {
-			LoomError::from(WeaveError::BadConfig(format!(
+			LoomError::from_error(WeaveError::BadConfig(format!(
 				"Number of tokens exceeds max tokens for model: {}",
 				content
 			)))


### PR DESCRIPTION
## Overview
Improve error handling by providing more flexibility for users of the library.

## Changes

1. **Modified `Weave` to `Llm` in `LoomError`**
   - More comprehensive code (as discussed)
2. **Implementation of `from_error` method**:
   - Added a new method `from_error<E>` to `LoomError`.
   - This method allows wrapping any error type that implements `Error + Send + Sync + 'static` into the `Llm` variant of `LoomError`.

## Usage Example

Users can now wrap their custom errors like this:
```rust
enum MyCustomError {
	#[error("Bad configuration: {0}")]
	BadConfig(String),
}
return Err(LoomError::from_error(MyCustomError::BadConfig(
	"Something went wrong".to_string(),
)));
```

## Additional
- used from_error across the code for WeaveError